### PR TITLE
#96-Added SettingLink links in a popup module

### DIFF
--- a/web/modules/custom/popup/css/popup.css
+++ b/web/modules/custom/popup/css/popup.css
@@ -1,0 +1,49 @@
+.setwrap button {
+  width: 100%;
+  height: 40px;
+  font-size: 14px !important;
+}
+.setwrap button {
+  background: #fff;
+  border: none;
+  border-bottom: 1px solid rgb(219,219,219);
+}
+
+.ui-widget-overlay {
+  background-color: rgba(0,0,0,0.65) !important;
+  opacity: unset !important;
+}
+.setwrap button a {
+  text-decoration: none;
+}
+.ui-dialog-titlebar.ui-corner-all.ui-widget-header.ui-helper-clearfix {
+  display: none;
+}
+.ui-dialog {
+  max-height: 480px !important;
+}
+.ui-dialog #drupal-modal {
+  padding: unset !important;
+  overflow-y: unset !important;
+  max-height: 480px !important;
+}
+
+.ui-dialog.ui-corner-all.ui-widget.ui-widget-content.ui-front {
+  animation: 0.4s popup-animation backwards;
+  position: fixed;
+  top: 87.39px !important;
+  left: 480.9px !important;
+}
+
+@keyframes popup-animation {
+  0%,
+  to {
+    opacity: 1;
+    -webkit-transform: scale(1.4);
+    transform: scale(1.4);
+  }
+  100% {
+    opacity: 1;
+    -webkit-transform: scale(1);
+    transform: scale(1);
+  } }

--- a/web/modules/custom/popup/js/settingspopup.js
+++ b/web/modules/custom/popup/js/settingspopup.js
@@ -1,0 +1,10 @@
+(function($, Drupal) {
+    Drupal.behaviors.visual = {
+        attach: function(context, settings) {
+            $(context).find('a.cancel').on('click', function() {
+                document.querySelector('button.ui-dialog-titlebar-close').click();
+            });
+        }
+    }
+})(jQuery, Drupal);
+

--- a/web/modules/custom/popup/popup.info.yml
+++ b/web/modules/custom/popup/popup.info.yml
@@ -1,0 +1,4 @@
+name: Popup module
+type: module
+description: A module that will show links in a modal form.
+core_version_requirement: ^8 || ^9

--- a/web/modules/custom/popup/popup.libraries.yml
+++ b/web/modules/custom/popup/popup.libraries.yml
@@ -1,0 +1,6 @@
+global:
+  css:
+    theme:
+      css/popup.css: {}
+  js:
+    js/settingspopup.js: {}

--- a/web/modules/custom/popup/popup.routing.yml
+++ b/web/modules/custom/popup/popup.routing.yml
@@ -1,0 +1,7 @@
+popup.settingslink:
+  path: '/users/settings'
+  defaults:
+    _title: 'Setting'
+    _controller: '\Drupal\popup\Controller\SettingController::setting'
+  requirements:
+    _permission: 'access content'

--- a/web/modules/custom/popup/src/Controller/SettingController.php
+++ b/web/modules/custom/popup/src/Controller/SettingController.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Drupal\popup\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * A controller class.
+ */
+class SettingController extends ControllerBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setting() {
+    $set = [];
+    $set['contain'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => 'setwrap',
+      ],
+    ];
+    $set['contain']['changepass'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/changepass'],
+            ],
+            '#value' => 'Change Password',
+          ],
+    ];
+    $set['contain']['nametag'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/nametag'],
+            ],
+            '#value' => 'Nametag',
+          ],
+    ];
+    $set['contain']['apps'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/apps'],
+            ],
+            '#value' => 'Apps And Websites',
+          ],
+    ];
+    $set['contain']['notification'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/notification'],
+            ],
+            '#value' => 'Notification',
+          ],
+    ];
+    $set['contain']['privacy'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/privacy'],
+            ],
+            '#value' => 'Privacy and Security',
+          ],
+    ];
+    $set['contain']['loginactivity'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/loginactivity'],
+            ],
+            '#value' => 'Login Activity',
+          ],
+    ];
+    $set['contain']['instamail'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#attributes' => [
+          'href' => ['/instamail'],
+        ],
+        '#value' => 'Emails from Instagram',
+      ],
+    ];
+    $set['contain']['report'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#attributes' => [
+          'href' => ['/report'],
+        ],
+        '#value' => 'Report a Problem',
+      ],
+    ];
+    $set['contain']['logout'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#attributes' => [
+          'href' => ['/user/logout'],
+        ],
+        '#value' => 'Logout',
+      ],
+    ];
+    $set['contain']['cancel'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#attributes' => [
+          'href' => ['#'],
+          'class' => ['cancel'],
+        ],
+        '#value' => 'Cancel',
+      ],
+    ];
+    $set['#attached']['library'][] = 'popup/global';
+    return $set;
+  }
+
+}

--- a/web/modules/custom/profile_block/templates/user-profile-block.html.twig
+++ b/web/modules/custom/profile_block/templates/user-profile-block.html.twig
@@ -3,7 +3,12 @@
     <div class='top'>  
         <a class='uname'><h4>{{ uname }}</h4></a>
         <div class='set_tab'><a href='edit' class='edit_profile'>Edit Profile</a> 
-        <a href='settings' class='settings'>Set</a></div>
+          <a class="use-ajax"
+   data-dialog-options="{&quot;height&quot;:560}"
+   data-dialog-type="modal"
+   href="/users/settings">
+  <i class="fas fa-cog"></i>
+</a></div>
     </div>
     <div class='wrapcount'> 
         <span>{{ post_count }}<a> posts</a></span> 


### PR DESCRIPTION
**Requirement:**
1.Their are different Setting links On the user_profile page which should get opened in a modal.
2. Create a different popup module and added a controller which will display all the settings link.
3. In the template file add a icon and modal link to open the controller page in modal.
4. Style the modal with reference to the original settings block on instagram site.

**ScreenShots:**
![Screenshot from 2022-03-28 17-29-36](https://user-images.githubusercontent.com/87809169/160393408-5937272b-3381-47b8-ad91-c90e596a5d83.png)
 