### PR TITLE
#92:adding edit settings for posts

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -61,6 +61,7 @@ module:
   page_cache: 0
   path: 0
   path_alias: 0
+  popup: 0
   profile_block: 0
   pseudo: 0
   quickedit: 0

--- a/config/sync/language/fr/taxonomy.vocabulary.hashtags.yml
+++ b/config/sync/language/fr/taxonomy.vocabulary.hashtags.yml
@@ -1,0 +1,1 @@
+name: Hashtags

--- a/config/sync/views.view.flag_followers_content.yml
+++ b/config/sync/views.view.flag_followers_content.yml
@@ -115,8 +115,8 @@ display:
           label: ''
           exclude: true
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ uid }} <a class="use-ajax" data-dialog-options="{&quot;width&quot;:800}" data-dialog-type="modal" href="users/editsettings">...</a>'
             make_link: false
             path: ''
             absolute: false

--- a/web/modules/custom/popup/popup.routing.yml
+++ b/web/modules/custom/popup/popup.routing.yml
@@ -1,7 +1,15 @@
 popup.settingslink:
-  path: '/users/settings'
+  path: "/users/settings"
   defaults:
-    _title: 'Setting'
+    _title: "Setting"
     _controller: '\Drupal\popup\Controller\SettingController::setting'
   requirements:
-    _permission: 'access content'
+    _permission: "access content"
+
+popup.editsettingslink:
+  path: "/users/editsettings"
+  defaults:
+    _title: "Edit Settings"
+    _controller: '\Drupal\popup\Controller\SettingController::editsetting'
+  requirements:
+    _permission: "access content"

--- a/web/modules/custom/popup/src/Controller/SettingController.php
+++ b/web/modules/custom/popup/src/Controller/SettingController.php
@@ -145,4 +145,119 @@ class SettingController extends ControllerBase {
     return $set;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function editsetting() {
+    $set = [];
+    $set['contain'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => 'setwrap',
+      ],
+    ];
+    $set['contain']['report'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/report'],
+              'style' => 'color:red',
+            ],
+            '#value' => 'Report',
+          ],
+    ];
+    $set['contain']['unfollow'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/unfollow'],
+              'style' => 'color:red',
+            ],
+            '#value' => 'Unfollow',
+          ],
+    ];
+    $set['contain']['gotopost'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/gotopost'],
+            ],
+            '#value' => 'Go to post ',
+          ],
+    ];
+    $set['contain']['taggedaccounts'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/taggedaccounts'],
+            ],
+            '#value' => 'Tagged Accounts',
+          ],
+    ];
+    $set['contain']['shareto'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/shareto'],
+            ],
+            '#value' => 'Share to...',
+          ],
+    ];
+    $set['contain']['copylink'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+          [
+            '#type' => 'html_tag',
+            '#tag' => 'a',
+            '#attributes' => [
+              'href' => ['/copylink'],
+            ],
+            '#value' => 'Copy link',
+          ],
+    ];
+    $set['contain']['embed'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#attributes' => [
+          'href' => ['/embed'],
+        ],
+        '#value' => 'Embed',
+      ],
+    ];
+
+    $set['contain']['cancel'] = [
+      '#type' => 'html_tag',
+      '#tag' => 'button',
+      [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#attributes' => [
+          'href' => ['#'],
+          'class' => ['cancel'],
+        ],
+        '#value' => 'Cancel',
+      ],
+    ];
+    $set['#attached']['library'][] = 'popup/global';
+    return $set;
+  }
+
 }

--- a/web/modules/custom/profile_block/templates/user-profile-block.html.twig
+++ b/web/modules/custom/profile_block/templates/user-profile-block.html.twig
@@ -6,7 +6,7 @@
           <a class="use-ajax"
    data-dialog-options="{&quot;height&quot;:560}"
    data-dialog-type="modal"
-   href="/users/settings">
+   href="./settings">
   <i class="fas fa-cog"></i>
 </a></div>
     </div>

--- a/web/themes/custom/instagram/scss/all/postblock.scss
+++ b/web/themes/custom/instagram/scss/all/postblock.scss
@@ -35,6 +35,24 @@
   }
 }
 
+.name .use-ajax {
+  padding-left: 420px !important;
+  @include mobile() {
+    padding-left: 180px !important;
+  }
+}
+
+.ui-dialog {
+  width: 400px !important;
+  border-radius: 20px;
+  @include mobile() {
+    width: 275px !important;
+  }
+  #drupal-modal {
+    border-radius: 20px;
+  }
+}
+
 .insta-gallery {
   @include laptop-l {
     width: 950px;


### PR DESCRIPTION
Adding Edit posts settings modal.

**Requirement:**
1.Their are different Setting links On the edit posts section of the posts page which should get opened in a modal.
2. Modify  popup module and display settings links.
3. Modify view Flag followers content and add modal in the replacement patterns. 
4. Style the modal with reference to the original settings block on instagram site.

Reference:

![Screenshot from 2022-03-28 19-34-34](https://user-images.githubusercontent.com/65488349/160415533-f3dee4c2-13be-4b81-adbe-e50ddddb26ec.png)


