### PR TITLE
#93 Infinite Scroll Implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "drupal/search_api_page": "^1.0@beta",
         "drupal/twig_tweak": "^3.1",
         "drupal/user_menu_avatar": "^6.0@RC",
+        "drupal/views_infinite_scroll": "^2.0",
         "drupal/views_slideshow": "^4.8"
     },
     "conflict": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0844ad65fe5dc6eb3f9aa80cfedf26db",
+    "content-hash": "4c03d97a029b13f19e033f8b9824a35f",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3186,6 +3186,62 @@
             "homepage": "https://www.drupal.org/project/user_menu_avatar",
             "support": {
                 "source": "https://git.drupalcode.org/project/user_menu_avatar"
+            }
+        },
+        {
+            "name": "drupal/views_infinite_scroll",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/views_infinite_scroll.git",
+                "reference": "2.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/views_infinite_scroll-2.0.0.zip",
+                "reference": "2.0.0",
+                "shasum": "9e1bc62131c8577609f2b2c520d749ac0a9b4142"
+            },
+            "require": {
+                "drupal/core": "^9.2"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0",
+                    "datestamp": "1641878440",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Bobík",
+                    "homepage": "https://www.drupal.org/user/123612"
+                },
+                {
+                    "name": "Neslee Canil Pinto",
+                    "homepage": "https://www.drupal.org/user/3580850"
+                },
+                {
+                    "name": "Remon",
+                    "homepage": "https://www.drupal.org/user/143827"
+                },
+                {
+                    "name": "Sam152",
+                    "homepage": "https://www.drupal.org/user/1485048"
+                }
+            ],
+            "description": "A pager which allows an infinite scroll effect for views.",
+            "homepage": "https://www.drupal.org/project/views_infinite_scroll",
+            "support": {
+                "source": "https://git.drupalcode.org/project/views_infinite_scroll"
             }
         },
         {

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -87,6 +87,7 @@ module:
   update: 0
   user: 0
   user_menu_avatar: 0
+  views_infinite_scroll: 0
   views_slideshow: 0
   views_slideshow_cycle: 0
   views_ui: 0

--- a/config/sync/language/fr/views.view.flag_followers_content.yml
+++ b/config/sync/language/fr/views.view.flag_followers_content.yml
@@ -18,8 +18,6 @@ display:
           tags:
             previous: '‹ Précédent'
             next: 'Suivant ›'
-            first: '« Premier'
-            last: 'Dernier »'
   page_1:
     display_title: Page
     display_options:

--- a/config/sync/language/ko/views.view.flag_followers_content.yml
+++ b/config/sync/language/ko/views.view.flag_followers_content.yml
@@ -18,8 +18,6 @@ display:
           tags:
             previous: '‹ 이전'
             next: '다음 ›'
-            first: '« 처음'
-            last: '마지막 »'
   page_1:
     display_title: 쪽
     display_options:

--- a/config/sync/views.view.flag_followers_content.yml
+++ b/config/sync/views.view.flag_followers_content.yml
@@ -20,6 +20,7 @@ dependencies:
     - node
     - text
     - user
+    - views_infinite_scroll
 _core:
   default_config_hash: 47IYi8RR_4zxJhMb26BYZgrrotG2TRVqZ9trCUVsGmU
 id: flag_followers_content
@@ -684,17 +685,15 @@ display:
           empty_zero: false
           hide_alter_empty: false
       pager:
-        type: full
+        type: infinite_scroll
         options:
           offset: 0
-          items_per_page: 10
+          items_per_page: 2
           total_pages: null
           id: 0
           tags:
             next: 'Next ›'
             previous: '‹ Previous'
-            first: '« First'
-            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -703,7 +702,10 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
+          views_infinite_scroll:
+            button_text: ''
+            automatically_load_content: true
+            initially_load_all_pages: false
       exposed_form:
         type: basic
         options:
@@ -834,6 +836,7 @@ display:
           required: false
           flag: bookmark
           user_scope: current
+      use_ajax: true
       header: {  }
       footer: {  }
       display_extenders: {  }


### PR DESCRIPTION
### Requirements: Implementing instagram style infinite scroll functionality.

### Implementation Steps:
1. Adding [Views Infinite Scroll](https://www.drupal.org/project/views_infinite_scroll) with composer.
2. Configuring homepage feed view to use infinite scroll functionality.

**Before Infinite Scroll:**
i) The pagination provided by Full pager for the views was being shown.
![infinite-scroll-before](https://user-images.githubusercontent.com/2410377/160779754-44cba2ea-1782-49be-8db2-2223c379a286.png)

**After infinite scroll implementation:**
i) After implementing infinite scroll the pagination will not be shown.
ii) As per current configuration 2 posts will get loaded on each scroll.
iii) In this issue infinite scroll has been applied on "Flag Followers Content" view.

**How to test?**
i) The module is configured to load content on homepage infinitely.
ii) Before starting with testing you will need to have ample number of posts to observe the change. So, add at least 10+ posts so on each load at least 2 posts would be sufficient.
iii) To test it load the homepage of insta-clone.
iv) Browse the homepage posts normal way as you scroll up.
v) You would notice the existing full pagination should be gone.
vi) You would observe that the posts are being loaded infinitely. Two posts at a time.