### PR TITLE
#112-created a story create feature

### DIFF
--- a/config/sync/core.base_field_override.node.story.promote.yml
+++ b/config/sync/core.base_field_override.node.story.promote.yml
@@ -1,0 +1,22 @@
+uuid: c7a514ad-4d1d-4ce3-86d3-ccb43641934f
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.story
+id: node.story.promote
+field_name: promote
+entity_type: node
+bundle: story
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/sync/core.entity_form_display.node.story.default.yml
+++ b/config/sync/core.entity_form_display.node.story.default.yml
@@ -1,0 +1,41 @@
+uuid: 5d3d5549-40fe-4e12-951c-eae4cef20d63
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.story.body
+    - field.field.node.story.field_images
+    - image.style.thumbnail
+    - node.type.story
+  module:
+    - image
+id: node.story.default
+targetEntityType: node
+bundle: story
+mode: default
+content:
+  field_images:
+    type: image_image
+    weight: 1
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  body: true
+  created: true
+  langcode: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.story.default.yml
+++ b/config/sync/core.entity_view_display.node.story.default.yml
@@ -1,0 +1,30 @@
+uuid: bb2c0990-4c22-4eea-a542-95ce666dc95a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.story.body
+    - field.field.node.story.field_images
+    - node.type.story
+  module:
+    - image
+    - user
+id: node.story.default
+targetEntityType: node
+bundle: story
+mode: default
+content:
+  field_images:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 0
+    region: content
+hidden:
+  body: true
+  langcode: true
+  links: true
+  search_api_excerpt: true

--- a/config/sync/core.entity_view_display.node.story.teaser.yml
+++ b/config/sync/core.entity_view_display.node.story.teaser.yml
@@ -1,0 +1,34 @@
+uuid: 97cf985a-a901-4c09-a0eb-bd658e7d45d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.story.body
+    - field.field.node.story.field_images
+    - node.type.story
+  module:
+    - text
+    - user
+id: node.story.teaser
+targetEntityType: node
+bundle: story
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  field_images: true
+  langcode: true
+  search_api_excerpt: true

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -79,6 +79,7 @@ module:
   shortcut: 0
   signupform: 0
   statistics: 0
+  story: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/config/sync/field.field.node.story.body.yml
+++ b/config/sync/field.field.node.story.body.yml
@@ -1,0 +1,23 @@
+uuid: a12f6f36-7aed-4b25-8142-69e47a1b9b86
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.story
+  module:
+    - text
+id: node.story.body
+field_name: body
+entity_type: node
+bundle: story
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/config/sync/field.field.node.story.field_images.yml
+++ b/config/sync/field.field.node.story.field_images.yml
@@ -1,0 +1,38 @@
+uuid: 7a3799bc-3859-4f1d-ad6b-7b8a8fa720b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_images
+    - node.type.story
+  module:
+    - image
+id: node.story.field_images
+field_name: field_images
+entity_type: node
+bundle: story
+label: Images
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/config/sync/field.storage.node.field_images.yml
+++ b/config/sync/field.storage.node.field_images.yml
@@ -1,0 +1,30 @@
+uuid: 01a9e135-3b15-4fc0-a2f4-f1fd4e76f5dd
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_images
+field_name: field_images
+entity_type: node
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.node.story.yml
+++ b/config/sync/language.content_settings.node.story.yml
@@ -1,0 +1,11 @@
+uuid: 0e1415e2-704f-4a08-9f12-a3fc17a63506
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.story
+id: node.story
+target_entity_type_id: node
+target_bundle: story
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.story.yml
+++ b/config/sync/node.type.story.yml
@@ -1,0 +1,18 @@
+uuid: 2055aeca-2697-4960-93ec-698a92c2313b
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Story
+type: story
+description: 'Story Created by the users'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: true

--- a/web/modules/custom/createpost/css/modal.css
+++ b/web/modules/custom/createpost/css/modal.css
@@ -262,3 +262,14 @@ a.choose {
   margin-bottom: 12px;
   text-decoration: none;
 }
+a.story-icon {
+  position: relative;
+  bottom: 30%;
+  right: 44%;
+  font-size: 24px;
+  background-color: #0095f6;
+  width: 10%;
+  height: 7%;
+  color: white !important;
+  text-align: center;
+}

--- a/web/modules/custom/createpost/src/Form/CreateNode.php
+++ b/web/modules/custom/createpost/src/Form/CreateNode.php
@@ -96,6 +96,7 @@ class CreateNode extends FormBase {
         '#type' => 'html_tag',
         '#tag' => 'div',
         '#value' => '
+        <a href="/storycreate" class ="story-icon"><i class="fab fa-discourse"></i></a>
         <a class ="choose" href ="/capture">Capture From Webcam</a>
         <span class = "choose">Select From Computer</span>',
         '#attributes' => [

--- a/web/modules/custom/story/css/storycreate.css
+++ b/web/modules/custom/story/css/storycreate.css
@@ -1,0 +1,19 @@
+form#story-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 14%;
+}
+input#edit-story-file-upload {
+  font-size: 23px;
+  color: white;
+  background: #0095f6;
+}
+input#edit-button {
+  color: white;
+  font-size: 23px;
+  margin-top: 26px;
+  width: 27.2rem;
+  background: #0095f6;
+  border: #0095f6;
+}

--- a/web/modules/custom/story/src/Form/StoryForm.php
+++ b/web/modules/custom/story/src/Form/StoryForm.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\story\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\File\FileUrlGenerator;
+use Drupal\Core\Extension\ExtensionList;
+use Drupal\Core\State\State;
+
+/**
+ * A class to create form for creating node.
+ */
+class StoryForm extends FormBase {
+  /**
+   * To Get the Current user details.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * To Load the file to database.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * To Save The file.
+   *
+   * @var Drupal\Core\State\State
+   */
+  protected $state;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(AccountInterface $account, EntityTypeManagerInterface $entity_type_manager, FileUrlGenerator $fileUrlGenerator, ExtensionList $extensionList, State $state) {
+    $this->account = $account;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->fileUrlGenerator = $fileUrlGenerator;
+    $this->extensionList = $extensionList;
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    // Instantiates this form class.
+    return new static(
+      // Load the service required to construct this class.
+      $container->get('current_user'),
+      $container->get('entity_type.manager'),
+      $container->get('file_url_generator'),
+      $container->get('extension.list.module'),
+      $container->get('state'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'story_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @RenderElement("html_tag");
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $public_store = 'public://multifield_images/';
+
+    $form['story_file'] = [
+      '#type' => 'managed_file',
+      '#upload_validators' => [
+        'file_validate_extensions' => ['zip ZIP jpeg jpg png gif'],
+      ],
+      '#attributes' => [
+        'class' => ['storyfile'],
+        'id' => ['imagefornode'],
+      ],
+      '#upload_location' => $public_store,
+    ];
+    $form['button'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('submit'),
+      '#attributes' => [
+        'class' => ['storysubmit'],
+      ],
+    ];
+
+    $form['#attached']['library'][] = 'story/global-styling';
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $story = $form_state->getValue('story_file');
+    $file = $this->entityTypeManager->getStorage('file')->load($story[0]);
+    $file->setPermanent();
+    $file->save();
+
+    $node = $this->entityTypeManager->getStorage('node')->create([
+      'type' => 'story',
+      'title' => ' ',
+    ]);
+    $node->field_images[] = [
+      'target_id' => $file->id(),
+      'alt' => '  ',
+      'title' => 'Title',
+    ];
+    $node->enforceIsNew();
+    $node->save();
+    $form_state->setRedirect('<front>');
+
+  }
+
+}

--- a/web/modules/custom/story/story.info.yml
+++ b/web/modules/custom/story/story.info.yml
@@ -1,0 +1,5 @@
+name: Story
+description: A story functionality the the insta-clone site.
+type: module
+core_version_requirement: ^8||^9
+package: Story

--- a/web/modules/custom/story/story.libraries.yml
+++ b/web/modules/custom/story/story.libraries.yml
@@ -1,0 +1,4 @@
+global-styling:
+  css:
+    theme:
+      css/storycreate.css: {}

--- a/web/modules/custom/story/story.routing.yml
+++ b/web/modules/custom/story/story.routing.yml
@@ -1,0 +1,7 @@
+story.open_form:
+  path: "/storycreate"
+  defaults:
+    _title: "Story Form"
+    _form: '\Drupal\story\Form\StoryForm'
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION
Requirement: Story blocks Create operations should contain a form with which user can create his story or else can delete the one which he has already created.

Description: This module provides you a option where the user can add a new story content to the site.

Testing Steps:
 1. Take fresh pull of the branch 
 2. if story module is not enabled just enable it through extend page.
 3. click on the menu icon where you click to create a new post .
 4. a small icon will appear at left corner.
 5. click on the icon you will go on the story page.
 6. choose a file and add story .
 
Some Screenshots:
![Screenshot from 2022-04-20 18-08-27](https://user-images.githubusercontent.com/87809169/164232154-922a9f7d-7e29-4d0a-a8db-13a307b54338.png)
![Screenshot from 2022-04-20 18-08-36](https://user-images.githubusercontent.com/87809169/164232182-d8662ffc-85f5-47c2-b6cc-cac7b42acbb1.png)
